### PR TITLE
Fix patterns glob in gemspec

### DIFF
--- a/grok.gemspec
+++ b/grok.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   files = Dir.glob("lib/**/*.rb")
-  files + Dir.glob("patterns/**")
+  files + Dir.glob("patterns/**/*")
   files + Dir.glob("test/")
 
   #svnrev = %x{svn info}.split("\n").grep(/Revision:/).first.split(" ").last.to_i


### PR DESCRIPTION
This patch updates the glob used by grok.gemspec so that the standard patterns files are included.