### PR TITLE
I suggest pointing the links to GitHub, not Google Code

### DIFF
--- a/grok.gemspec
+++ b/grok.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
 
   spec.authors = ["Jordan Sissel", "Pete Fritchman"]
   spec.email = ["jls@semicomplete.com", "petef@databits.net"]
-  spec.homepage = "http://code.google.com/p/semicomplete/wiki/Grok"
+  spec.homepage = "https://github.com/jordansissel/ruby-grok"
   spec.metadata = { "source_code_uri" => "https://github.com/jordansissel/ruby-grok" }
 end

--- a/grok.gemspec
+++ b/grok.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
   spec.authors = ["Jordan Sissel", "Pete Fritchman"]
   spec.email = ["jls@semicomplete.com", "petef@databits.net"]
   spec.homepage = "http://code.google.com/p/semicomplete/wiki/Grok"
+  spec.metadata = { "source_code_uri" => "https://github.com/jordansissel/ruby-grok" }
 end
-


### PR DESCRIPTION
The Google Code project seems to only refer to a C implementation from 2011,
and doesn't seem relevant anymore, except for historical purposes.